### PR TITLE
Add check if server settings exist for guild on ready

### DIFF
--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -5,10 +5,7 @@ import ServerSettingsRepository from "../repository/severSettings";
 export default async function ReadyEvent(discordClient: DiscordClient) {
 	Logger.info(`Ready to serve, found ${discordClient.guilds.cache.size} guilds`);
 
-	discordClient.guilds.cache.forEach(guild => {
-		CheckGuild(guild.id)
-	});
-
+	await Promise.all(discordClient.guilds.cache.map(guild => CheckGuild(guild.id)))
 	async function CheckGuild(guildId: any) {
 		Logger.info(`Checking for guild ${guildId}`);
 	

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -6,24 +6,28 @@ export default async function ReadyEvent(discordClient: DiscordClient) {
 	Logger.info(`Ready to serve, found ${discordClient.guilds.cache.size} guilds`);
 
 	discordClient.guilds.cache.forEach(guild => {
-		Logger.info(`Checking for guild ${guild.id}`);
-		ServerSettingsRepository.GetByGuildId(guild.id).then(serverSettings => {
-			if (serverSettings === null) {
-				ServerSettingsRepository.Save({
-					id: 0,
-					guildId: guild.id,
-					deleted: null,
-					prefix: ';',
-					logChannel: null,
-					modLogChannel: null,
-					systemNotice: true,
-					streamLiveRole: null,
-					streamShout: null,
-					adminRole: null, 
-					moderatorRole: null,
-				});
-				Logger.info(`Created guild ${guild.id}`);
-			}
-		});
+		CheckGuild(guild.id)
 	});
+
+	async function CheckGuild(guildId: any) {
+		Logger.info(`Checking for guild ${guildId}`);
+	
+		const serverSettings = await ServerSettingsRepository.GetByGuildId(guildId)
+		if (serverSettings === null) {
+			ServerSettingsRepository.Save({
+				id: 0,
+				guildId: guildId,
+				deleted: null,
+				prefix: ';',
+				logChannel: null,
+				modLogChannel: null,
+				systemNotice: true,
+				streamLiveRole: null,
+				streamShout: null,
+				adminRole: null, 
+				moderatorRole: null,
+			});
+			Logger.info(`Created guild ${guildId}`);
+		}
+	}
 }

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,9 +1,29 @@
 import { Client as DiscordClient } from "discord.js";
 import Logger from "../lib/log";
+import ServerSettingsRepository from "../repository/severSettings";
 
 export default async function ReadyEvent(discordClient: DiscordClient) {
-	Logger.info(`Ready to serve`);
+	Logger.info(`Ready to serve, found ${discordClient.guilds.cache.size} guilds`);
 
-	// TODO:
-	// Check for any added guilds while offline to create settings objects for
+	discordClient.guilds.cache.forEach(guild => {
+		Logger.info(`Checking for guild ${guild.id}`);
+		ServerSettingsRepository.GetByGuildId(guild.id).then(serverSettings => {
+			if (serverSettings === null) {
+				ServerSettingsRepository.Save({
+					id: 0,
+					guildId: guild.id,
+					deleted: null,
+					prefix: ';',
+					logChannel: null,
+					modLogChannel: null,
+					systemNotice: true,
+					streamLiveRole: null,
+					streamShout: null,
+					adminRole: null, 
+					moderatorRole: null,
+				});
+				Logger.info(`Created guild ${guild.id}`);
+			}
+		});
+	});
 }


### PR DESCRIPTION
When the Discord Client first connects with Discord, a ready event is triggered. In this the guilds the bot is in should be checked if it has corresponding settings in the database. If not, they should be created with default values.