### PR TITLE
Starting of normalisation of resolvers

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -84,10 +84,10 @@ export default class ConfigCommand implements ICommand {
 
 			let whiteListedRolesString = 'Off';
 			if (wl.roles.length > 0) {
-				whiteListedRolesString = wl.roles.map(async r => {
+				whiteListedRolesString = (await Promise.all(wl.roles.map(async r => {
 					const role = await objectResolver.ResolveGuildRole(guild, r.id);
 					return role?.name + " (" + r.id + ")";
-				}).join("\n");
+				}))).join("\n");
 			}
 
 			const embed = createMessageEmbed({

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -5,6 +5,7 @@ import WhiteListRepository from "../repository/whiteList";
 import TwitchClient from "../lib/twitch";
 import createMessageEmbed from "../wrapper/discord/messageEmbed";
 import { SetMutedPermissions, SetMutedPermissionsForChannel } from "../lib/mutedRole";
+import ObjectResolver from "../lib/objectResolver";
 
 export default class ConfigCommand implements ICommand {
 
@@ -20,6 +21,7 @@ export default class ConfigCommand implements ICommand {
 		const guildId = message.guild?.id;
 		const ss = await ServerSettingsRepository.GetByGuildId(guildId);
 		const wl = await WhiteListRepository.GetByGuildId(guildId);
+		const objectResolver = new ObjectResolver(discordClient);
 		if (!ss || !wl || !message.guild) {
 			return;
 		}
@@ -30,19 +32,19 @@ export default class ConfigCommand implements ICommand {
 
 			let logChannelString = 'Off';
 			if (ss.logChannel) {
-				const logChannel = guild.channels.resolve(ss.logChannel);
+				const logChannel = await objectResolver.ResolveGuildChannel(guild, ss.logChannel);
 				logChannelString = `${logChannel?.name || 'ERR-404'} (${ss.logChannel})`;
 			}
 
 			let streamLiveRoleString = 'Off';
 			if (ss.streamLiveRole) {
-				const liveRole = guild.roles.resolve(ss.streamLiveRole)
+				const liveRole = await objectResolver.ResolveGuildRole(guild, ss.streamLiveRole);
 				streamLiveRoleString = `${liveRole?.name || 'ERR-404'} (${ss.streamLiveRole})`;
 			}
 
 			let streamShoutString = 'Off';
 			if (ss.streamShout) {
-				const shoutChannel = guild.channels.resolve(ss.streamShout)
+				const shoutChannel = await objectResolver.ResolveGuildChannel(guild, ss.streamShout)
 				streamShoutString = `${shoutChannel?.name || 'ERR-404'} (${ss.streamShout})`;
 			}
 
@@ -53,25 +55,25 @@ export default class ConfigCommand implements ICommand {
 
 			let adminRoleString = 'Off';
 			if (ss.adminRole) {
-				const adminRole = guild.roles.resolve(ss.adminRole)
+				const adminRole = await objectResolver.ResolveGuildRole(guild, ss.adminRole);
 				adminRoleString = `${adminRole?.name || 'ERR-404'} (${ss.adminRole})`;
 			}
 
 			let modRoleString = 'Off';
 			if (ss.moderatorRole) {
-				const modRole = guild.roles.resolve(ss.moderatorRole)
+				const modRole = await objectResolver.ResolveGuildRole(guild, ss.moderatorRole);
 				modRoleString = `${modRole?.name || 'ERR-404'} (${ss.moderatorRole})`;
 			}
 
 			let muteRoleString = 'Off';
 			if (ss.muteRole) {
-				const muteRole = guild.roles.resolve(ss.muteRole)
+				const muteRole = await objectResolver.ResolveGuildRole(guild, ss.muteRole);
 				muteRoleString = `${muteRole?.name || 'ERR-404'} (${ss.muteRole})`;
 			}
 			
 			let muteChannelString = 'Off';
 			if (ss.muteChannel) {
-				const muteChannel = guild.channels.resolve(ss.muteChannel);
+				const muteChannel = await objectResolver.ResolveGuildChannel(guild, ss.muteChannel);
 				muteChannelString = `${muteChannel?.name || 'ERR-404'} (${ss.muteChannel})`;
 			}
 
@@ -82,7 +84,10 @@ export default class ConfigCommand implements ICommand {
 
 			let whiteListedRolesString = 'Off';
 			if (wl.roles.length > 0) {
-				whiteListedRolesString = wl.roles.map(r => guild.roles.resolve(r.id)?.name + " (" + r.id + ")").join("\n");
+				whiteListedRolesString = wl.roles.map(async r => {
+					const role = await objectResolver.ResolveGuildRole(guild, r.id);
+					return role?.name + " (" + r.id + ")";
+				}).join("\n");
 			}
 
 			const embed = createMessageEmbed({
@@ -149,7 +154,7 @@ export default class ConfigCommand implements ICommand {
 				if (value == 'null') {
 					ss.logChannel = null;
 				} else {
-					const logChannel = guild.channels.cache.find(x => x.id == value || x.name == value);
+					const logChannel = await objectResolver.ResolveGuildChannel(guild, value);
 					if (!logChannel) {
 						message.reply('Couldnt find channel');
 						return;
@@ -162,7 +167,7 @@ export default class ConfigCommand implements ICommand {
 				if (value == 'null') {
 					ss.streamLiveRole = null;
 				} else {
-					const liveRole = guild.roles.cache.find(x => x.id == value || x.name == value);
+					const liveRole = await objectResolver.ResolveGuildRole(guild, value);
 					if (!liveRole) {
 						message.reply('Couldnt find role');
 						return;
@@ -173,7 +178,7 @@ export default class ConfigCommand implements ICommand {
 				if (value == 'null') {
 					ss.streamShout = null;
 				} else {
-					const promotionChannel = guild.channels.cache.find(x => x.id == value || x.name == value);
+					const promotionChannel = await objectResolver.ResolveGuildChannel(guild, value);
 					if (!promotionChannel) {
 						message.reply('Couldnt find channel');
 						return;
@@ -195,7 +200,7 @@ export default class ConfigCommand implements ICommand {
 				if (value == 'null') {
 					ss.adminRole = null;
 				} else {
-					const adminRole = guild.roles.cache.find(x => x.id == value || x.name == value);
+					const adminRole = await objectResolver.ResolveGuildRole(guild, value);
 					if (!adminRole) {
 						message.reply('Couldnt find role');
 						return;
@@ -206,7 +211,7 @@ export default class ConfigCommand implements ICommand {
 				if (value == 'null') {
 					ss.moderatorRole = null;
 				} else {
-					const modRole = guild.roles.cache.find(x => x.id == value || x.name == value);
+					const modRole = await objectResolver.ResolveGuildRole(guild, value);
 					if (!modRole) {
 						message.reply('Couldnt find role');
 						return;
@@ -217,7 +222,7 @@ export default class ConfigCommand implements ICommand {
 				if (value == 'null') {
 					ss.muteRole = null;
 				} else {
-					const muteRole = guild.roles.cache.find(x => x.id == value || x.name == value);
+					const muteRole = await objectResolver.ResolveGuildRole(guild, value);
 					if (!muteRole) {
 						message.reply('Couldnt find role');
 						return;
@@ -230,12 +235,12 @@ export default class ConfigCommand implements ICommand {
 					ss.muteChannel = null;
 					
 					if (ss.muteRole && oldMutedChannelId) {
-						const muteChannel = guild.channels.cache.find(x => x.id == oldMutedChannelId);
+						const muteChannel = await objectResolver.ResolveGuildChannel(guild, oldMutedChannelId);
 						if (!muteChannel) {
 							return;
 						}
 
-						const muteRole = await message.guild?.roles.fetch(ss.muteRole);
+						const muteRole = await objectResolver.ResolveGuildRole(guild, ss.muteRole);
 						if (!muteRole) {
 							return;
 						}
@@ -243,7 +248,7 @@ export default class ConfigCommand implements ICommand {
 						SetMutedPermissionsForChannel(muteRole, muteChannel, null)
 					}
 				} else {
-					const muteChannel = guild.channels.cache.find(x => x.id == value || x.name == value);
+					const muteChannel = await objectResolver.ResolveGuildChannel(guild, value);
 					if (!muteChannel) {
 						message.reply('Couldnt find channel');
 						return;
@@ -251,7 +256,7 @@ export default class ConfigCommand implements ICommand {
 					ss.muteChannel = muteChannel.id;
 
 					if (ss.muteRole) {
-						const muteRole = await message.guild?.roles.fetch(ss.muteRole!);
+						const muteRole = await objectResolver.ResolveGuildRole(guild, ss.muteRole);
 						if (!muteRole) {
 							return;
 						}
@@ -279,8 +284,8 @@ export default class ConfigCommand implements ICommand {
 				}
 				WhiteListRepository.AddGame(guildId, game.id, game.name);
 			} else if (key == 'whiteListedRoles') {
-				const role = guild.roles.cache.find(r => r.id === value || r.name === value)
-				if (role === undefined) { 
+				const role = await objectResolver.ResolveGuildRole(guild, value);
+				if (role == null) {
 					message.reply('Role id does not exist in this guild');
 					return;
 				}

--- a/src/commands/unmute.ts
+++ b/src/commands/unmute.ts
@@ -2,6 +2,7 @@ import { ICommand, PermissionLevel } from "./base";
 import { Message, Client } from "discord.js";
 import MutedRepository from "../repository/muted";
 import ServerSettingsRepository from "../repository/serverSettings";
+import ObjectResolver from "../lib/objectResolver";
 
 export default class UnmuteCommand implements ICommand {
 	
@@ -14,20 +15,26 @@ export default class UnmuteCommand implements ICommand {
 	helpText = "Unmutes user";
 	
 	async run(discordClient: Client, message: Message, args: string[]) {
-		if (args.length !== 1 || message.mentions.members === null || message.mentions.members.size === 0) {
+		if (args.length !== 1) {
 			message.reply(this.usageText);
 			return;
 		}
 
-		const guildId = message.guild?.id;
-		const serverSettings = await ServerSettingsRepository.GetByGuildId(guildId);
+		const guild = message.guild;
+		if (guild === null) {
+			message.reply("Command can only be run inside of a guild");
+			return;
+		}
+
+		const serverSettings = await ServerSettingsRepository.GetByGuildId(guild.id);
 		if (serverSettings === null || serverSettings.muteRole === null) {
 			message.reply("Muting has not been configured");
 			return;
 		}
 		
-		const guildMember = message.mentions.members.first()
-		if (!guildMember || !args[0].includes(guildMember!.id)) { 
+		const objectResolver = new ObjectResolver(discordClient);
+		const guildMember = await objectResolver.ResolveGuildMember(guild, args[0]);
+		if (!guildMember) {
 			message.reply(this.usageText);
 			return;
 		}
@@ -38,17 +45,19 @@ export default class UnmuteCommand implements ICommand {
 			return;
 		}
 
-		const mute = await MutedRepository.GetRunning(guildId, guildMember.id)
+		const mute = await MutedRepository.GetRunning(guild.id, guildMember.id)
 		if (mute === null) {
+			message.reply(`User "${guildMember.user.tag}" is not muted`);
 			return;
 		}
 
 		MutedRepository.SetUnmuted(mute.id, new Date())
-		const user = message.guild!.members.resolve(guildMember.id);
+		const user = guild.members.resolve(guildMember.id);
 		if (user === null) { 
 			return;
 		}
 	
-		user.roles.remove(muteRole, "Mute manually removed via command")
+		user.roles.remove(muteRole, "Mute manually removed via command");
+		message.reply(`User "${guildMember.user.tag}" has been unmuted`);
 	}
 }

--- a/src/events/presenceUpdate.ts
+++ b/src/events/presenceUpdate.ts
@@ -78,14 +78,6 @@ async function LiveRole(discordClient: DiscordClient, serverSettings: ServerSett
 
 async function StreamShout(discordClient: DiscordClient, serverSettings: ServerSettings, oldPresence: Presence | null, newPresence: Presence, wasStreaming: boolean, whiteListed: boolean, streamingActivity: Activity|undefined) {
 	if (!oldPresence || !newPresence?.member || wasStreaming || !streamingActivity?.url || !whiteListed || !serverSettings?.streamShout) {
-		Logger.error(`Could not do streamshout`, {
-			oldPresence: !!oldPresence,
-			newPresence: !!newPresence?.member,
-			wasStreaming,
-			streamingActivityUrl: streamingActivity?.url,
-			whiteListed: whiteListed,
-			streamShout: !!serverSettings?.streamShout,
-		});
 		return;
 	}
 

--- a/src/lib/objectResolver.ts
+++ b/src/lib/objectResolver.ts
@@ -51,13 +51,30 @@ export default class ObjectResolver {
 			}
 		}
 
-		const result = guild.members.cache.filter(x => {
+		const usernameMatch = guild.members.cache.filter(x => {
 			return x.user.username == query
 		});
-		const resultKey = result.firstKey();
-		if (resultKey) {
-			return result.get(resultKey) ?? null;
+		if (usernameMatch.keys.length > 1) {
+			return null;
 		}
+		const usernameMatchKey = usernameMatch.firstKey();
+		if (usernameMatchKey) {
+			// More than one user matches, unconfident result
+			return usernameMatch.get(usernameMatchKey) ?? null;
+		}
+
+		const lowernameMatch = guild.members.cache.filter(x => {
+			return x.user.username.toLowerCase() == query.toLowerCase()
+		});
+		if (lowernameMatch.keys.length > 1) {
+			// More than one user matches, unconfident result
+			return null;
+		}
+		const lowernameMatchKey = lowernameMatch.firstKey();
+		if (lowernameMatchKey) {
+			return lowernameMatch.get(lowernameMatchKey) ?? null;
+		}
+
 		return null;
 	}
 

--- a/src/lib/objectResolver.ts
+++ b/src/lib/objectResolver.ts
@@ -1,0 +1,84 @@
+import { Client, Guild, GuildMember, GuildChannel, Role, User  } from "discord.js";
+
+const userTagRegex = /(.{2,32})\#((?!0{4})[0-9]{4})$/;
+
+function isNumeric(s: string) {
+	for (let i = 0; i < s.length; i++) {
+		const d = s.charCodeAt(i);
+		if (d < 48 || d > 57) {
+			return false
+		}
+	}
+	return true
+}
+
+export default class ObjectResolver {
+
+	private client: Client;
+
+	constructor(client: Client) {
+		this.client = client;
+	}
+
+	async ResolveGuildMember(guild: Guild, query: string): Promise<GuildMember|null> {
+		query = query.trim();
+
+		// Strip down mention tags
+		if (query.startsWith('<@') && query.endsWith('>')) {
+			query = query.slice(2, -1);
+			if (query.startsWith('!'))
+				query = query.slice(1);
+		}
+
+		// Check if its an ID
+		if (isNumeric(query)) {
+			return this.GetGuildMember(guild, query);
+		}
+
+		// First check for a # to decrease the usage of regex.
+		if (query.indexOf('#') > -1 && userTagRegex.test(query)) {
+			const regexmatch = userTagRegex.exec(query);
+			if (!regexmatch) {
+				throw new Error();
+			}
+			const username = regexmatch[1];
+			const discriminator = regexmatch[2];
+			const result = guild.members.cache.find(x => {
+				return x.user.username == username && x.user.discriminator == discriminator
+			});
+			if (result) {
+				return result;
+			}
+		}
+
+		const result = guild.members.cache.filter(x => {
+			return x.user.username == query
+		});
+		const resultKey = result.firstKey();
+		if (resultKey) {
+			return result.get(resultKey) ?? null;
+		}
+		return null;
+	}
+
+	async GetGuildMember(guild: Guild, id: string): Promise<GuildMember|null> {
+		return guild.members.resolve(id)
+	}
+
+	async ResolveGuildChannel(guild: Guild, query: string): Promise<GuildChannel|null> {
+		const result = guild.channels.cache.find(x => x.id == query || x.name == query);
+		if (result) {
+			return result;
+		}
+		return null;
+	}
+
+	async ResolveGuildRole(guild: Guild, query: string): Promise<Role|null> {
+		const result = guild.roles.cache.find(x => x.id == query || x.name == query);
+		if (result) {
+			return result;
+		}
+		return null;
+	}
+
+}


### PR DESCRIPTION
This will allow users to target without mentions with a looser comparison

Instead of: `;mute @usermention 1M reasoning`
It can just be `;mute username 1M reasoning` which would allow mods to mute people without it being in a public channel